### PR TITLE
feat: Enable resources to be objects as well.

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -43,6 +43,44 @@ test("getTableNames should be able to extract a dynamo db table name", (t) => {
   );
 });
 
+test("getTableNames should be able to extract a dynamo db table name when resources is not a list", (t) => {
+  t.deepEqual(
+    getCreateTableCommandInput(
+      {
+        Resources: {
+          MyTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "my-table",
+              AttributeDefinitions: [
+                { AttributeName: "id", AttributeType: "S" },
+              ],
+              KeySchema: [
+                {
+                  AttributeName: "id",
+                  KeyType: "HASH",
+                },
+              ],
+            },
+          },
+        },
+      },
+    ),
+    [
+      {
+        TableName: "my-table",
+        AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+        KeySchema: [
+          {
+            AttributeName: "id",
+            KeyType: "HASH",
+          },
+        ],
+      },
+    ]
+  );
+});
+
 test("getTableNames should be able to extract a dynamo db table names with other resources and different stacks", (t) => {
   t.deepEqual(
     getCreateTableCommandInput([

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,10 +23,13 @@ function isDynamoDBResource(resource: Resource): resource is DynamoDBResource {
   return resource.Type === "AWS::DynamoDB::Table";
 }
 
+type AWSResourceList = { Resources: { [key: string]: Resource } }
+
 export function getCreateTableCommandInput(
-  resources: { Resources: { [key: string]: Resource } }[]
+  resources: AWSResourceList[] | AWSResourceList
 ): CreateTableCommandInput[] {
-  const flattenedResources = resources.flatMap((r) =>
+  const resourcesList = Array.isArray(resources) ? resources : [resources];
+  const flattenedResources = resourcesList.flatMap((r) =>
     Object.values(r.Resources)
   );
   return flattenedResources.filter(isDynamoDBResource).map((r) => r.Properties);


### PR DESCRIPTION
According to the Serverless documentation the correct way to do AWS resources is to have
one Resources object with key-values and not a list of these object. However, since both
work we keep the possibility to specify it as a list too.